### PR TITLE
Implement user visual preferences

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,4 @@ NUMEROLOGY_API_KEY=your-numerology-key
 STRIPE_SECRET_KEY=test-stripe-key
 FRONTEND_URL=http://localhost:3000
 PORT=3001
+SUPABASE_STORAGE_BUCKET=assets

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Copiez le fichier `.env.example` vers `.env` puis renseignez :
 - `NUMEROLOGY_API_KEY`
 - `STRIPE_SECRET_KEY`
 - `FRONTEND_URL`
+- `SUPABASE_STORAGE_BUCKET`
 
 ### Déploiement
 Le frontend est prêt à être déployé sur Vercel. Le backend peut être déployé sur la plateforme de votre choix (Railway, Vercel serverless, etc.).

--- a/backend/models/preferences.js
+++ b/backend/models/preferences.js
@@ -1,0 +1,4 @@
+// User preferences table in Supabase
+module.exports = {
+  table: 'user_preferences',
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
         "@supabase/supabase-js": "^2.39.3",
         "express": "^4.18.2",
         "jsonwebtoken": "^9.0.2",
+        "multer": "^1.4.5-lts.1",
         "node-cron": "^4.1.0",
         "node-fetch": "^2.6.7",
         "openai": "^3.2.1",
@@ -128,6 +129,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -179,6 +186,23 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -229,6 +253,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -263,6 +302,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -657,6 +702,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -817,11 +868,51 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
+      "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
+      "deprecated": "Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -859,6 +950,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -908,6 +1008,12 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
     "node_modules/proxy-addr": {
@@ -961,6 +1067,27 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -1141,6 +1268,29 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/stripe": {
       "version": "12.18.0",
       "resolved": "https://registry.npmjs.org/stripe/-/stripe-12.18.0.tgz",
@@ -1182,6 +1332,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -1196,6 +1352,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -1250,6 +1412,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
     "@supabase/supabase-js": "^2.39.3",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",
+    "multer": "^1.4.5-lts.1",
     "node-cron": "^4.1.0",
     "node-fetch": "^2.6.7",
     "openai": "^3.2.1",

--- a/backend/routes/preferenceRoutes.js
+++ b/backend/routes/preferenceRoutes.js
@@ -1,0 +1,43 @@
+const express = require('express');
+const router = express.Router();
+const authMiddleware = require('../utils/auth');
+const {
+  getPreferenceByUserId,
+  createPreference,
+  updatePreference,
+} = require('../services/preferenceService');
+
+router.get('/preferences/:user_id', authMiddleware, async (req, res) => {
+  try {
+    if (req.user.id !== req.params.user_id) {
+      return res.status(403).json({ error: 'forbidden' });
+    }
+    const pref = await getPreferenceByUserId(req.params.user_id);
+    res.json(pref || {});
+  } catch (e) {
+    res.status(500).json({ error: 'pref_error' });
+  }
+});
+
+router.post('/preferences', authMiddleware, async (req, res) => {
+  try {
+    const pref = await createPreference({ ...req.body, user_id: req.user.id });
+    res.json(pref);
+  } catch (e) {
+    res.status(500).json({ error: 'pref_error' });
+  }
+});
+
+router.put('/preferences/:user_id', authMiddleware, async (req, res) => {
+  try {
+    if (req.user.id !== req.params.user_id) {
+      return res.status(403).json({ error: 'forbidden' });
+    }
+    const pref = await updatePreference(req.params.user_id, req.body);
+    res.json(pref);
+  } catch (e) {
+    res.status(500).json({ error: 'pref_error' });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/uploadRoutes.js
+++ b/backend/routes/uploadRoutes.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const multer = require('multer');
+const router = express.Router();
+const authMiddleware = require('../utils/auth');
+const { supabase } = require('../config/supabase');
+
+const upload = multer({ storage: multer.memoryStorage() });
+
+router.post('/upload/background', authMiddleware, upload.single('file'), async (req, res) => {
+  try {
+    if (!req.file) return res.status(400).json({ error: 'no_file' });
+    const path = `backgrounds/${req.user.id}/${Date.now()}_${req.file.originalname}`;
+    const { error } = await supabase.storage
+      .from('assets')
+      .upload(path, req.file.buffer, { contentType: req.file.mimetype, upsert: true });
+    if (error) return res.status(500).json({ error: 'upload_error' });
+    const { data } = supabase.storage.from('assets').getPublicUrl(path);
+    res.json({ url: data.publicUrl });
+  } catch (e) {
+    res.status(500).json({ error: 'upload_error' });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -2,6 +2,8 @@ const express = require('express');
 const { supabase } = require('./config/supabase');
 const userRoutes = require('./routes/userRoutes');
 const paymentRoutes = require('./routes/paymentRoutes');
+const preferenceRoutes = require('./routes/preferenceRoutes');
+const uploadRoutes = require('./routes/uploadRoutes');
 const { startSchedulers } = require('./scheduler');
 
 const app = express();
@@ -22,6 +24,8 @@ app.get('/profile', authMiddleware, async (req, res) => {
 
 app.use('/api', userRoutes);
 app.use('/api', paymentRoutes);
+app.use('/api', preferenceRoutes);
+app.use('/api', uploadRoutes);
 
 // Start background tasks
 startSchedulers();

--- a/backend/services/preferenceService.js
+++ b/backend/services/preferenceService.js
@@ -1,0 +1,44 @@
+const { supabase } = require('../config/supabase');
+
+async function getPreferenceByUserId(userId) {
+  const { data, error } = await supabase
+    .from('user_preferences')
+    .select('*')
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (error) throw error;
+  return data;
+}
+
+async function createPreference(pref) {
+  const { data, error } = await supabase
+    .from('user_preferences')
+    .insert({
+      user_id: pref.user_id,
+      theme: pref.theme,
+      color_primary: pref.color_primary,
+      background_image: pref.background_image,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+async function updatePreference(userId, updates) {
+  updates.updated_at = new Date().toISOString();
+  const { data, error } = await supabase
+    .from('user_preferences')
+    .update(updates)
+    .eq('user_id', userId)
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+module.exports = {
+  getPreferenceByUserId,
+  createPreference,
+  updatePreference,
+};

--- a/frontend/pages/[username]/index.js
+++ b/frontend/pages/[username]/index.js
@@ -4,18 +4,32 @@ import { useEffect, useState } from 'react';
 export default function UserSite() {
   const { query } = useRouter();
   const [profile, setProfile] = useState(null);
+  const [prefs, setPrefs] = useState(null);
 
   useEffect(() => {
     if (!query.username) return;
     fetch(`/api/site/${query.username}`)
       .then(res => res.json())
-      .then(setProfile)
-      .catch(() => setProfile(null));
+      .then(data => {
+        setProfile(data);
+        return fetch(`/api/preferences/${data.id}`);
+      })
+      .then(res => (res && res.ok ? res.json() : null))
+      .then(setPrefs)
+      .catch(() => {
+        setProfile(null);
+        setPrefs(null);
+      });
   }, [query.username]);
 
   if (!profile) return <div>Chargement...</div>;
+  const styles = {
+    backgroundImage: prefs && prefs.background_image ? `url(${prefs.background_image})` : 'none',
+    color: prefs && prefs.color_primary ? prefs.color_primary : 'inherit',
+    padding: '20px',
+  };
   return (
-    <div>
+    <div style={styles}>
       <h1>Mini-site de {query.username}</h1>
       <p>Thème astro : {profile.zodiac_sign || 'N/A'}</p>
       <p>Chemin de vie : {profile.lifePath || 'Calcul en cours'}</p>

--- a/frontend/pages/settings.js
+++ b/frontend/pages/settings.js
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+
+const themes = ['astro', 'zen', 'oracle', 'minimal', 'cosmos'];
+
+export default function Settings() {
+  const [profile, setProfile] = useState(null);
+  const [prefs, setPrefs] = useState({ theme: 'astro', color_primary: '#000000', background_image: '' });
+  const [file, setFile] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const profRes = await fetch('/api/profile');
+        const profData = await profRes.json();
+        const user = Array.isArray(profData) ? profData[0] : profData;
+        setProfile(user);
+        const prefRes = await fetch(`/api/preferences/${user.id}`);
+        if (prefRes.ok) {
+          const prefData = await prefRes.json();
+          if (prefData) setPrefs(prefData);
+        }
+      } catch (e) {
+        // ignore
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  const handleChange = e => {
+    setPrefs({ ...prefs, [e.target.name]: e.target.value });
+  };
+
+  const handleFile = e => {
+    setFile(e.target.files[0]);
+  };
+
+  const uploadBackground = async () => {
+    if (!file) return null;
+    const form = new FormData();
+    form.append('file', file);
+    const res = await fetch('/api/upload/background', { method: 'POST', body: form });
+    const data = await res.json();
+    return data.url;
+  };
+
+  const save = async () => {
+    if (!profile) return;
+    const method = prefs.id ? 'PUT' : 'POST';
+    const url = prefs.id ? `/api/preferences/${profile.id}` : '/api/preferences';
+    let bgUrl = prefs.background_image;
+    if (file) {
+      const uploaded = await uploadBackground();
+      if (uploaded) bgUrl = uploaded;
+    }
+    await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...prefs, background_image: bgUrl }),
+    });
+  };
+
+  if (loading) return <div>Chargement...</div>;
+
+  return (
+    <div>
+      <h1>Préférences visuelles</h1>
+      <label>
+        Thème
+        <select name="theme" value={prefs.theme} onChange={handleChange}>
+          {themes.map(t => (
+            <option key={t} value={t}>{t}</option>
+          ))}
+        </select>
+      </label>
+      <br />
+      <label>
+        Couleur principale
+        <input type="color" name="color_primary" value={prefs.color_primary} onChange={handleChange} />
+      </label>
+      <br />
+      <label>
+        Image de fond
+        <input type="file" onChange={handleFile} />
+        <input type="text" name="background_image" value={prefs.background_image || ''} onChange={handleChange} placeholder="ou URL" />
+      </label>
+      <br />
+      <button onClick={save}>Enregistrer</button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add user preferences model, service, routes
- support background upload to Supabase storage
- connect new routes in the Express app
- expose a settings page to manage theme, color and background image
- render user minisite with saved preferences
- document new SUPABASE_STORAGE_BUCKET variable

## Testing
- `node -e "require('./backend/server');"` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68406e6464988328b3dbdea8fcc899f3