### PR TITLE
Implement user registration with mini-site creation

### DIFF
--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -4,14 +4,85 @@ const { generatePersonalEnergyMessage } = require('../services/openaiService');
 const { getNumerologyInfo } = require('../services/numerologyService');
 const { getDailyHoroscope } = require('../services/horoscopeService');
 const { getClientSiteData } = require('../services/clientSiteService');
-const { getUserById } = require('../services/userService');
+const { createUser, getUserById, getUserByUsername } = require('../services/userService');
+const { createProfile } = require('../services/profileService');
+const { createPreference } = require('../services/preferenceService');
+const { createSubscription } = require('../services/subscriptionService');
 const {
   generateDailyJournal,
   getJournalEntriesByUsername,
 } = require('../services/journalService');
+const crypto = require('crypto');
 const { supabase } = require('../config/supabase');
 const authMiddleware = require('../utils/auth');
 const subscriptionMiddleware = require('../utils/subscriptionAuth');
+
+function getZodiacSign(dateStr) {
+  const d = new Date(dateStr);
+  const day = d.getUTCDate();
+  const month = d.getUTCMonth() + 1;
+  if ((month === 3 && day >= 21) || (month === 4 && day <= 19)) return 'aries';
+  if ((month === 4 && day >= 20) || (month === 5 && day <= 20)) return 'taurus';
+  if ((month === 5 && day >= 21) || (month === 6 && day <= 20)) return 'gemini';
+  if ((month === 6 && day >= 21) || (month === 7 && day <= 22)) return 'cancer';
+  if ((month === 7 && day >= 23) || (month === 8 && day <= 22)) return 'leo';
+  if ((month === 8 && day >= 23) || (month === 9 && day <= 22)) return 'virgo';
+  if ((month === 9 && day >= 23) || (month === 10 && day <= 22)) return 'libra';
+  if ((month === 10 && day >= 23) || (month === 11 && day <= 21)) return 'scorpio';
+  if ((month === 11 && day >= 22) || (month === 12 && day <= 21)) return 'sagittarius';
+  if ((month === 12 && day >= 22) || (month === 1 && day <= 19)) return 'capricorn';
+  if ((month === 1 && day >= 20) || (month === 2 && day <= 18)) return 'aquarius';
+  return 'pisces';
+}
+
+// Register a new user with mini-site setup
+router.post('/register', async (req, res) => {
+  const { email, password, firstName, dob, gender, username } = req.body;
+  if (!email || !password || !firstName || !dob) {
+    return res.status(400).json({ error: 'missing_fields' });
+  }
+  try {
+    // Verify username availability or generate one
+    let finalUsername = (username || firstName).toLowerCase();
+    try {
+      const existing = await getUserByUsername(finalUsername);
+      if (existing) {
+        finalUsername = `${firstName.toLowerCase()}-${Math.floor(Math.random() * 10000)}`;
+      }
+    } catch (e) {
+      // ignore if not found
+    }
+
+    const { data: authUser, error: authError } = await supabase.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+    });
+    if (authError) return res.status(400).json({ error: 'auth_error' });
+    const userId = authUser.user.id;
+
+    await createUser({ id: userId, email, username: finalUsername, first_name: firstName, birth_date: dob });
+
+    const profileId = crypto.randomUUID();
+    await createProfile({ id: profileId, user_id: userId, gender, first_name: firstName, birth_date: dob });
+
+    await createPreference({ user_id: userId, theme: 'astro', color_primary: '#000000', background_image: '' });
+
+    await createSubscription(userId, 'free_trial');
+
+    await generateDailyJournal(userId);
+
+    await getNumerologyInfo(dob);
+    const sign = getZodiacSign(dob);
+    await getDailyHoroscope(sign, dob);
+    await generatePersonalEnergyMessage(firstName, dob);
+
+    res.json({ id: userId, username: finalUsername, profileId });
+  } catch (e) {
+    console.error('register error', e);
+    res.status(500).json({ error: 'register_error' });
+  }
+});
 
 // Endpoint to generate personalized energy message
 router.get('/energy-message/:firstName/:dob', authMiddleware, async (req, res) => {

--- a/backend/services/profileService.js
+++ b/backend/services/profileService.js
@@ -1,0 +1,22 @@
+const { supabase } = require('../config/supabase');
+
+async function createProfile(profile) {
+  const { data, error } = await supabase
+    .from('profiles')
+    .insert(profile)
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+async function getProfileByUserId(userId) {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (error) throw error;
+  return data;
+}
+
+module.exports = { createProfile, getProfileByUserId };

--- a/frontend/pages/register.js
+++ b/frontend/pages/register.js
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+
+export default function Register() {
+  const [form, setForm] = useState({ firstName: '', email: '', password: '', dob: '', gender: 'female', username: '' });
+  const [status, setStatus] = useState('');
+
+  const handleChange = e => setForm({ ...form, [e.target.name]: e.target.value });
+
+  const submit = async e => {
+    e.preventDefault();
+    setStatus('loading');
+    const res = await fetch('/api/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    });
+    setStatus(res.ok ? 'success' : 'error');
+  };
+
+  return (
+    <div>
+      <h1>Inscription</h1>
+      <form onSubmit={submit}>
+        <label>
+          Prénom
+          <input name="firstName" value={form.firstName} onChange={handleChange} required />
+        </label>
+        <br />
+        <label>
+          Email
+          <input type="email" name="email" value={form.email} onChange={handleChange} required />
+        </label>
+        <br />
+        <label>
+          Mot de passe
+          <input type="password" name="password" value={form.password} onChange={handleChange} required />
+        </label>
+        <br />
+        <label>
+          Date de naissance
+          <input type="date" name="dob" value={form.dob} onChange={handleChange} required />
+        </label>
+        <br />
+        <label>
+          Genre
+          <select name="gender" value={form.gender} onChange={handleChange}>
+            <option value="female">Femme</option>
+            <option value="male">Homme</option>
+            <option value="other">Autre</option>
+          </select>
+        </label>
+        <br />
+        <label>
+          Nom d'utilisateur (optionnel)
+          <input name="username" value={form.username} onChange={handleChange} />
+        </label>
+        <br />
+        <button type="submit">Créer mon mini-site</button>
+      </form>
+      {status === 'loading' && <p>Création en cours...</p>}
+      {status === 'success' && <p>Compte créé ! Vous pouvez vous connecter.</p>}
+      {status === 'error' && <p>Erreur lors de l'inscription.</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `profileService` for managing profiles in Supabase
- extend `userRoutes` with `/register` to create a user, profile and initial data
- create Next.js signup page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684072e270848328a802cc4ee36a8228