### PR TITLE
Implement basic admin panel

### DIFF
--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -1,5 +1,5 @@
 // Users table structure in Supabase
 module.exports = {
   table: 'users',
-  columns: ['id', 'email', 'username', 'first_name', 'birth_date'],
+  columns: ['id', 'email', 'username', 'first_name', 'birth_date', 'role'],
 };

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -1,0 +1,57 @@
+const express = require('express');
+const router = express.Router();
+const { supabase } = require('../config/supabase');
+
+// GET /admin/users - list of users
+router.get('/users', async (req, res) => {
+  try {
+    const { data, error } = await supabase
+      .from('users')
+      .select('id,email,username,created_at,subscriptions(plan,status,created_at)');
+    if (error) throw error;
+    const users = data.map(u => ({
+      id: u.id,
+      email: u.email,
+      username: u.username,
+      subscription: u.subscriptions && u.subscriptions[0] ? u.subscriptions[0] : null,
+      created_at: u.created_at,
+    }));
+    res.json(users);
+  } catch (e) {
+    res.status(500).json({ error: 'fetch_users_error' });
+  }
+});
+
+// GET /admin/minisites - list of minisites
+router.get('/minisites', async (req, res) => {
+  try {
+    const { data, error } = await supabase
+      .from('user_preferences')
+      .select('theme, created_at, users(username)');
+    if (error) throw error;
+    const sites = data.map(row => ({
+      username: row.users.username,
+      theme: row.theme,
+      created_at: row.created_at,
+    }));
+    res.json(sites);
+  } catch (e) {
+    res.status(500).json({ error: 'fetch_sites_error' });
+  }
+});
+
+// GET /admin/subscriptions - list of subscriptions
+router.get('/subscriptions', async (req, res) => {
+  try {
+    const { data, error } = await supabase
+      .from('subscriptions')
+      .select('plan,status,created_at');
+    if (error) throw error;
+    res.json(data);
+  } catch (e) {
+    res.status(500).json({ error: 'fetch_subscriptions_error' });
+  }
+});
+
+module.exports = router;
+

--- a/backend/server.js
+++ b/backend/server.js
@@ -4,6 +4,7 @@ const userRoutes = require('./routes/userRoutes');
 const paymentRoutes = require('./routes/paymentRoutes');
 const preferenceRoutes = require('./routes/preferenceRoutes');
 const uploadRoutes = require('./routes/uploadRoutes');
+const adminRoutes = require('./routes/adminRoutes');
 const { startSchedulers } = require('./scheduler');
 
 const app = express();
@@ -15,6 +16,7 @@ app.get('/', (req, res) => {
 
 // Example protected route using Supabase Auth
 const authMiddleware = require('./utils/auth');
+const adminAuth = require('./utils/adminAuth');
 
 app.get('/profile', authMiddleware, async (req, res) => {
   const { data, error } = await supabase.from('profiles').select('*');
@@ -26,6 +28,7 @@ app.use('/api', userRoutes);
 app.use('/api', paymentRoutes);
 app.use('/api', preferenceRoutes);
 app.use('/api', uploadRoutes);
+app.use('/admin', authMiddleware, adminAuth, adminRoutes);
 
 // Start background tasks
 startSchedulers();

--- a/backend/utils/__tests__/adminAuth.test.js
+++ b/backend/utils/__tests__/adminAuth.test.js
@@ -1,0 +1,36 @@
+const adminAuth = require('../adminAuth');
+
+jest.mock('../../config/supabase', () => {
+  const supabase = {
+    from: jest.fn(() => supabase),
+    select: jest.fn(() => supabase),
+    eq: jest.fn(() => supabase),
+    single: jest.fn(),
+  };
+  return { supabase };
+});
+const { supabase } = require('../../config/supabase');
+
+describe('adminAuth middleware', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('calls next when user is admin', async () => {
+    supabase.single.mockResolvedValue({ data: { role: 'admin' } });
+    const req = { user: { id: '1' } };
+    const res = { status: jest.fn(() => res), json: jest.fn() };
+    const next = jest.fn();
+    await adminAuth(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('returns 403 when user is not admin', async () => {
+    supabase.single.mockResolvedValue({ data: { role: 'user' } });
+    const req = { user: { id: '1' } };
+    const res = { status: jest.fn(() => res), json: jest.fn() };
+    const next = jest.fn();
+    await adminAuth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+

--- a/backend/utils/adminAuth.js
+++ b/backend/utils/adminAuth.js
@@ -1,0 +1,22 @@
+const { supabase } = require('../config/supabase');
+
+/**
+ * Middleware to verify that the authenticated user has the admin role.
+ */
+module.exports = async function(req, res, next) {
+  try {
+    const { data, error } = await supabase
+      .from('users')
+      .select('role')
+      .eq('id', req.user.id)
+      .single();
+    if (error) throw error;
+    if (!data || data.role !== 'admin') {
+      return res.status(403).json({ error: 'forbidden' });
+    }
+    next();
+  } catch (e) {
+    res.status(500).json({ error: 'admin_auth_error' });
+  }
+};
+

--- a/frontend/pages/admin/index.js
+++ b/frontend/pages/admin/index.js
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+
+export default function AdminDashboard() {
+  const [users, setUsers] = useState(null);
+  const [sites, setSites] = useState(null);
+  const [subs, setSubs] = useState(null);
+
+  useEffect(() => {
+    async function load() {
+      const [uRes, sRes, subRes] = await Promise.all([
+        fetch('/admin/users'),
+        fetch('/admin/minisites'),
+        fetch('/admin/subscriptions'),
+      ]);
+      if (uRes.ok) setUsers(await uRes.json());
+      if (sRes.ok) setSites(await sRes.json());
+      if (subRes.ok) setSubs(await subRes.json());
+    }
+    load();
+  }, []);
+
+  if (!users || !sites || !subs) return <div>Chargement...</div>;
+
+  return (
+    <div>
+      <h1>Admin Panel</h1>
+      <h2>Utilisateurs</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Email</th>
+            <th>Username</th>
+            <th>Plan</th>
+            <th>Date inscription</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map(u => (
+            <tr key={u.id}>
+              <td>{u.id}</td>
+              <td>{u.email}</td>
+              <td>{u.username}</td>
+              <td>{u.subscription ? u.subscription.plan : 'N/A'}</td>
+              <td>{u.created_at?.slice(0,10)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h2>Mini-sites</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Username</th>
+            <th>Thème</th>
+            <th>Date création</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sites.map(s => (
+            <tr key={s.username}>
+              <td>{s.username}</td>
+              <td>{s.theme}</td>
+              <td>{s.created_at?.slice(0,10)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h2>Abonnements</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Plan</th>
+            <th>Statut</th>
+            <th>Date</th>
+          </tr>
+        </thead>
+        <tbody>
+          {subs.map(s => (
+            <tr key={s.created_at}>
+              <td>{s.plan}</td>
+              <td>{s.status}</td>
+              <td>{s.created_at?.slice(0,10)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add adminAuth middleware for admin role checking
- add /admin routes for users, minisites and subscriptions
- wire admin routes in Express server
- extend users model with role column
- create Next.js admin dashboard page
- add unit tests for adminAuth middleware

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6840773a00808328ba1918a03593fb41