### PR TITLE
Add Jest tests and validation helpers

### DIFF
--- a/backend/services/__tests__/horoscopeService.test.js
+++ b/backend/services/__tests__/horoscopeService.test.js
@@ -1,0 +1,30 @@
+const { getDailyHoroscope } = require('../horoscopeService');
+const fetch = require('node-fetch');
+
+jest.mock('node-fetch', () => jest.fn());
+
+jest.mock('../../config/supabase', () => {
+  const supabase = {
+    from: jest.fn(() => supabase),
+    insert: jest.fn(() => supabase),
+  };
+  return { supabase };
+});
+const { supabase } = require('../../config/supabase');
+
+describe('getDailyHoroscope', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('calls horoscope API and stores result', async () => {
+    fetch.mockResolvedValue({ json: () => Promise.resolve({ description: 'Great' }) });
+    supabase.insert.mockResolvedValue({});
+    const desc = await getDailyHoroscope('aries', '1990-01-01');
+    expect(desc).toBe('Great');
+    expect(fetch).toHaveBeenCalled();
+    expect(supabase.from).toHaveBeenCalledWith('horoscopes');
+  });
+
+  it('throws for invalid date', async () => {
+    await expect(getDailyHoroscope('aries', '01-01-1990')).rejects.toThrow('invalid_dob');
+  });
+});

--- a/backend/services/__tests__/numerologyService.test.js
+++ b/backend/services/__tests__/numerologyService.test.js
@@ -1,0 +1,34 @@
+const { getNumerologyInfo } = require('../numerologyService');
+const fetch = require('node-fetch');
+
+jest.mock('node-fetch', () => jest.fn());
+jest.mock('../../config/supabase', () => {
+  const supabase = {
+    from: jest.fn(() => supabase),
+    insert: jest.fn(() => supabase),
+  };
+  return { supabase };
+});
+const { supabase } = require('../../config/supabase');
+
+describe('getNumerologyInfo', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('calls numerology API and stores result', async () => {
+    fetch.mockResolvedValue({ json: () => Promise.resolve({ life_path: 5 }) });
+    supabase.insert.mockResolvedValue({});
+
+    const result = await getNumerologyInfo('1990-01-01');
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://numerologyapi.com/api/v1/life-path?date_of_birth=1990-01-01',
+      { headers: { 'X-Api-Key': undefined } }
+    );
+    expect(supabase.from).toHaveBeenCalledWith('numerology_results');
+    expect(result).toEqual({ lifePath: 5 });
+  });
+
+  it('throws for invalid date', async () => {
+    await expect(getNumerologyInfo('01-01-1990')).rejects.toThrow('invalid_dob');
+  });
+});

--- a/backend/services/__tests__/openaiService.test.js
+++ b/backend/services/__tests__/openaiService.test.js
@@ -1,0 +1,39 @@
+const { generatePersonalEnergyMessage } = require('../openaiService');
+
+jest.mock('openai', () => {
+  return {
+    Configuration: jest.fn(),
+    OpenAIApi: jest.fn().mockImplementation(() => ({
+      createChatCompletion: jest.fn(() =>
+        Promise.resolve({ data: { choices: [{ message: { content: 'Hi' } }] } })
+      ),
+    })),
+  };
+});
+
+jest.mock('../../config/supabase', () => {
+  const supabase = {
+    from: jest.fn(() => supabase),
+    insert: jest.fn(() => supabase),
+  };
+  return { supabase };
+});
+const { supabase } = require('../../config/supabase');
+
+describe('generatePersonalEnergyMessage', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('generates message and stores in db', async () => {
+    const message = await generatePersonalEnergyMessage('Jane', '1990-01-01');
+    expect(message).toBe('Hi');
+    expect(supabase.from).toHaveBeenCalledWith('energy_messages');
+  });
+
+  it('throws when missing first name', async () => {
+    await expect(generatePersonalEnergyMessage('', '1990-01-01')).rejects.toThrow('firstName_required');
+  });
+
+  it('throws for invalid date', async () => {
+    await expect(generatePersonalEnergyMessage('Jane', '01-01-1990')).rejects.toThrow('invalid_dob');
+  });
+});

--- a/backend/services/horoscopeService.js
+++ b/backend/services/horoscopeService.js
@@ -1,5 +1,6 @@
 const fetch = require('node-fetch');
 const { supabase } = require('../config/supabase');
+const { assertValidBirthDate, assertRequired } = require('../utils/validators');
 
 /**
  * Fetch daily horoscope for a zodiac sign from external API and store result.
@@ -7,6 +8,8 @@ const { supabase } = require('../config/supabase');
  * @param {string} birthDate YYYY-MM-DD user birth date
  */
 async function getDailyHoroscope(sign, birthDate) {
+  assertRequired(sign, 'sign');
+  assertValidBirthDate(birthDate);
   try {
     const response = await fetch(`https://aztro.sameerkumar.website/?sign=${sign}&day=today`, { method: 'POST' });
     const data = await response.json();

--- a/backend/services/numerologyService.js
+++ b/backend/services/numerologyService.js
@@ -1,5 +1,6 @@
 const fetch = require('node-fetch');
 const { supabase } = require('../config/supabase');
+const { assertValidBirthDate } = require('../utils/validators');
 
 /**
  * Call NumerologyAPI to compute life path number for given birth date.
@@ -7,6 +8,7 @@ const { supabase } = require('../config/supabase');
  * @param {string} birthDate - Date of birth YYYY-MM-DD
  */
 async function getNumerologyInfo(birthDate) {
+  assertValidBirthDate(birthDate);
   const url = `https://numerologyapi.com/api/v1/life-path?date_of_birth=${birthDate}`;
   const response = await fetch(url, {
     headers: { 'X-Api-Key': process.env.NUMEROLOGY_API_KEY },

--- a/backend/services/openaiService.js
+++ b/backend/services/openaiService.js
@@ -1,5 +1,6 @@
 const { Configuration, OpenAIApi } = require('openai');
 const { supabase } = require('../config/supabase');
+const { assertValidBirthDate, assertRequired } = require('../utils/validators');
 
 // Configure OpenAI client using API key from environment
 const configuration = new Configuration({
@@ -13,6 +14,8 @@ const openai = new OpenAIApi(configuration);
  * @param {string} birthDate - Date of birth YYYY-MM-DD
  */
 async function generatePersonalEnergyMessage(firstName, birthDate, welcome = false) {
+  assertRequired(firstName, 'firstName');
+  assertValidBirthDate(birthDate);
   let prompt = `Create a short daily energy message for ${firstName} born on ${birthDate}.`;
   if (welcome) {
     prompt += ' Welcome the user to Astero in one friendly sentence.';

--- a/backend/utils/__tests__/auth.test.js
+++ b/backend/utils/__tests__/auth.test.js
@@ -1,0 +1,35 @@
+const auth = require('../auth');
+
+jest.mock('../../config/supabase', () => {
+  const supabase = {
+    auth: {
+      getUser: jest.fn(),
+    },
+  };
+  return { supabase };
+});
+const { supabase } = require('../../config/supabase');
+
+describe('auth middleware', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('calls next with valid token', async () => {
+    supabase.auth.getUser.mockResolvedValue({ data: { user: { id: '1' } } });
+    const req = { headers: { authorization: 'Bearer token' } };
+    const res = { status: jest.fn(() => res), json: jest.fn() };
+    const next = jest.fn();
+    await auth(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toEqual({ id: '1' });
+  });
+
+  it('returns 401 with invalid token', async () => {
+    supabase.auth.getUser.mockResolvedValue({ error: 'bad' });
+    const req = { headers: { authorization: 'Bearer bad' } };
+    const res = { status: jest.fn(() => res), json: jest.fn() };
+    const next = jest.fn();
+    await auth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/backend/utils/validators.js
+++ b/backend/utils/validators.js
@@ -1,0 +1,17 @@
+function validateBirthDate(dob) {
+  return /^\d{4}-\d{2}-\d{2}$/.test(dob);
+}
+
+function assertValidBirthDate(dob) {
+  if (!validateBirthDate(dob)) {
+    throw new Error('invalid_dob');
+  }
+}
+
+function assertRequired(value, name) {
+  if (!value) {
+    throw new Error(`${name}_required`);
+  }
+}
+
+module.exports = { validateBirthDate, assertValidBirthDate, assertRequired };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "concurrently \"npm --prefix backend start\" \"npm --prefix frontend run dev\"",
     "build": "npm --prefix frontend run build",
-    "start": "npm --prefix backend start"
+    "start": "npm --prefix backend start",
+    "test": "npm --prefix backend test"
   },
   "devDependencies": {
     "concurrently": "^7.6.0"


### PR DESCRIPTION
## Summary
- add simple validators and use them in services
- create Jest tests for numerology, OpenAI and horoscope services
- add auth middleware tests
- expose backend tests via `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684088ddeb80832889850cc9b7b5c664