### PR TITLE
Add role-based access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,9 @@ Le frontend est prêt à être déployé sur Vercel. Le backend peut être dépl
 - Modèle `users` géré dans Supabase.
 - Route sécurisée `/api/generateUserContent` pour créer le contenu des mini-sites.
 - Chaque utilisateur possède une page dédiée disponible sur `/[username]` affichant son thème astro, son chemin de vie et son message énergétique.
+
+## Fonctionnalités Sprint 14
+- Gestion des rôles utilisateur avec middleware `securityMiddleware`.
+- Route `GET /admin/dashboard` réservée aux admins.
+- Route `GET /api/user/profile` pour le profil connecté.
+

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -2,6 +2,11 @@ const express = require('express');
 const router = express.Router();
 const { supabase } = require('../config/supabase');
 
+// Simple admin dashboard route
+router.get('/dashboard', async (req, res) => {
+  res.json({ message: 'Admin dashboard' });
+});
+
 // GET /admin/users - list of users
 router.get('/users', async (req, res) => {
   try {

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -6,7 +6,7 @@ const { getNumerologyInfo } = require('../services/numerologyService');
 const { getDailyHoroscope } = require('../services/horoscopeService');
 const { getClientSiteData } = require('../services/clientSiteService');
 const { createUser, getUserById, getUserByUsername } = require('../services/userService');
-const { createProfile } = require('../services/profileService');
+const { createProfile, getProfileByUserId } = require('../services/profileService');
 const { createPreference } = require('../services/preferenceService');
 const { createSubscription } = require('../services/subscriptionService');
 const {
@@ -17,6 +17,7 @@ const crypto = require('crypto');
 const { supabase } = require('../config/supabase');
 const authMiddleware = require('../utils/auth');
 const subscriptionMiddleware = require('../utils/subscriptionAuth');
+const securityMiddleware = require('../utils/securityMiddleware');
 
 // Register a new user with mini-site setup
 router.post('/register', async (req, res) => {
@@ -147,6 +148,26 @@ router.post('/generateDailyJournal', authMiddleware, subscriptionMiddleware, asy
     res.json(entry);
   } catch (e) {
     res.status(500).json({ error: 'journal_error' });
+  }
+});
+
+// Retrieve current user profile
+router.get('/user/profile', authMiddleware, securityMiddleware(['admin', 'user', 'premium']), async (req, res) => {
+  try {
+    const profile = await getProfileByUserId(req.user.id);
+    res.json(profile || {});
+  } catch (e) {
+    res.status(500).json({ error: 'profile_error' });
+  }
+});
+
+// Legacy endpoint kept for backward compatibility
+router.get('/profile', authMiddleware, securityMiddleware(['admin', 'user', 'premium']), async (req, res) => {
+  try {
+    const profile = await getProfileByUserId(req.user.id);
+    res.json(profile || {});
+  } catch (e) {
+    res.status(500).json({ error: 'profile_error' });
   }
 });
 

--- a/backend/services/__tests__/authService.test.js
+++ b/backend/services/__tests__/authService.test.js
@@ -1,0 +1,27 @@
+const { getUserRole, checkRole } = require('../authService');
+
+jest.mock('../../config/supabase', () => {
+  const supabase = {
+    from: jest.fn(() => supabase),
+    select: jest.fn(() => supabase),
+    eq: jest.fn(() => supabase),
+    single: jest.fn()
+  };
+  return { supabase };
+});
+const { supabase } = require('../../config/supabase');
+
+describe('authService', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns user role', async () => {
+    supabase.single.mockResolvedValue({ data: { role: 'admin' } });
+    const role = await getUserRole('1');
+    expect(role).toBe('admin');
+  });
+
+  it('checkRole verifies allowed roles', () => {
+    expect(checkRole('admin', ['admin'])).toBe(true);
+    expect(checkRole('user', ['admin'])).toBe(false);
+  });
+});

--- a/backend/services/authService.js
+++ b/backend/services/authService.js
@@ -1,0 +1,28 @@
+const { supabase } = require('../config/supabase');
+
+/**
+ * Retrieve the role of a user from Supabase.
+ *
+ * RLS policy suggestion on `users` table:
+ * enable row level security;
+ * create policy "Users can view own role" on users
+ *   for select using (auth.uid() = id);
+ */
+async function getUserRole(userId) {
+  const { data, error } = await supabase
+    .from('users')
+    .select('role')
+    .eq('id', userId)
+    .single();
+  if (error) throw error;
+  return data ? data.role : null;
+}
+
+/**
+ * Check if a role is part of the allowed roles list.
+ */
+function checkRole(role, allowedRoles = []) {
+  return allowedRoles.includes(role);
+}
+
+module.exports = { getUserRole, checkRole };

--- a/backend/utils/__tests__/securityMiddleware.test.js
+++ b/backend/utils/__tests__/securityMiddleware.test.js
@@ -1,0 +1,40 @@
+const securityMiddleware = require('../securityMiddleware');
+
+jest.mock('../../services/authService', () => ({
+  getUserRole: jest.fn()
+}));
+const { getUserRole } = require('../../services/authService');
+
+describe('securityMiddleware', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('calls next when role allowed', async () => {
+    getUserRole.mockResolvedValue('admin');
+    const req = { user: { id: '1' } };
+    const res = { status: jest.fn(() => res), json: jest.fn() };
+    const next = jest.fn();
+    await securityMiddleware(['admin'])(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(req.userRole).toBe('admin');
+  });
+
+  it('returns 403 when role not allowed', async () => {
+    getUserRole.mockResolvedValue('user');
+    const req = { user: { id: '1' } };
+    const res = { status: jest.fn(() => res), json: jest.fn() };
+    const next = jest.fn();
+    await securityMiddleware(['admin'])(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 on error', async () => {
+    getUserRole.mockRejectedValue(new Error('db'));
+    const req = { user: { id: '1' } };
+    const res = { status: jest.fn(() => res), json: jest.fn() };
+    const next = jest.fn();
+    await securityMiddleware(['admin'])(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/backend/utils/securityMiddleware.js
+++ b/backend/utils/securityMiddleware.js
@@ -1,0 +1,20 @@
+const { getUserRole } = require('../services/authService');
+
+/**
+ * Generic role-based access control middleware.
+ * @param {string[]} roles Allowed roles to access the route
+ */
+module.exports = function securityMiddleware(roles = []) {
+  return async function(req, res, next) {
+    try {
+      const role = await getUserRole(req.user.id);
+      if (!roles.length || roles.includes(role)) {
+        req.userRole = role;
+        return next();
+      }
+      return res.status(403).json({ error: 'forbidden' });
+    } catch (e) {
+      res.status(500).json({ error: 'role_check_error' });
+    }
+  };
+};


### PR DESCRIPTION
## Summary
- implement `authService` for role retrieval
- create `securityMiddleware` for role checks
- secure `/user/profile` and `/admin/dashboard`
- document new Sprint 14 features
- test new auth service and middleware

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68408c5409c08328b94af14d000ea4b5