### PR TITLE
Create QLYK Studio landing page

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -3,13 +3,13 @@
 @tailwind utilities;
 
 :root {
-  color-scheme: light;
+  color-scheme: dark;
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background-color: #f5f5f8;
+  background-color: #050814;
 }
 
 body {
-  @apply bg-slate-50 text-slate-800 min-h-screen;
+  @apply bg-slate-950 text-white min-h-screen;
 }
 
 main {
@@ -17,17 +17,17 @@ main {
 }
 
 a {
-  @apply text-brand hover:underline;
+  @apply text-brand-light hover:text-white;
 }
 
 .button-primary {
-  @apply inline-flex items-center justify-center rounded-full bg-brand text-white font-medium px-6 py-3 shadow-soft transition hover:bg-brand/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand;
+  @apply inline-flex items-center justify-center rounded-full bg-gradient-to-r from-brand to-brand-bright px-6 py-3 text-sm font-semibold text-white shadow-soft transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-brand-bright focus:ring-offset-2 focus:ring-offset-slate-900;
 }
 
-.card {
-  @apply bg-white rounded-3xl shadow-soft border border-slate-100;
+.button-secondary {
+  @apply inline-flex items-center justify-center rounded-full border border-white/20 bg-white/5 px-6 py-3 text-sm font-semibold text-white/80 transition hover:border-white/40 hover:text-white;
 }
 
-.section-title {
-  @apply text-xl font-semibold flex items-center gap-2 text-slate-900;
+.glass-card {
+  @apply rounded-3xl border border-white/10 bg-white/5 backdrop-blur shadow-soft;
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,119 +1,226 @@
-'use client';
-
-import { useEffect, useState } from "react";
-import RecipeForm from "../components/RecipeForm";
-import RecipeCard from "../components/RecipeCard";
-import HistoryPanel, { type HistoryEntry } from "../components/HistoryPanel";
-import { generateRecipe, type GeneratedRecipe, type RecipeInput } from "../lib/recipeGenerator";
-
-const STORAGE_KEY = "assistant-recette-pro-history";
-
 const HomePage = () => {
-  const [currentRecipe, setCurrentRecipe] = useState<GeneratedRecipe | null>(null);
-  const [history, setHistory] = useState<HistoryEntry[]>([]);
-  const [isGenerating, setIsGenerating] = useState(false);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    try {
-      const stored = window.localStorage.getItem(STORAGE_KEY);
-      if (stored) {
-        const parsed: HistoryEntry[] = JSON.parse(stored);
-        setHistory(parsed);
-        if (parsed[0]) {
-          setCurrentRecipe(parsed[0].recipe);
-        }
-      }
-    } catch (error) {
-      console.error("Impossible de charger l'historique", error);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(history));
-  }, [history]);
-
-  const handleGenerate = (input: RecipeInput) => {
-    setIsGenerating(true);
-    window.setTimeout(() => {
-      const recipe = generateRecipe(input);
-      setCurrentRecipe(recipe);
-      setHistory((prev) => {
-        const next: HistoryEntry[] = [
-          { id: recipe.id, createdAt: new Date().toISOString(), recipe },
-          ...prev.filter((entry) => entry.recipe.title !== recipe.title || entry.recipe.servings !== recipe.servings),
-        ].slice(0, 10);
-        return next;
-      });
-      setIsGenerating(false);
-    }, 420);
-  };
-
-  const handleSelectFromHistory = (id: string) => {
-    const entry = history.find((item) => item.id === id);
-    if (entry) {
-      setCurrentRecipe(entry.recipe);
-    }
-  };
-
-  const handleClearHistory = () => {
-    setHistory([]);
-  };
-
   return (
-    <main className="px-4 py-10 sm:px-6 lg:px-10">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">
-        <section className="relative overflow-hidden rounded-3xl bg-gradient-to-r from-brand to-brand/80 p-8 text-white shadow-soft">
-          <div className="max-w-3xl space-y-4">
-            <span className="inline-flex items-center gap-2 rounded-full bg-white/20 px-4 py-1 text-xs font-medium uppercase tracking-wide">
-              Assistant Recette Pro
+    <main className="bg-slate-950 text-white">
+      <div className="relative overflow-hidden">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(76,111,255,0.35),_transparent_55%)]" />
+        <div className="absolute inset-y-0 right-0 w-1/2 bg-[radial-gradient(circle_at_70%_30%,_rgba(0,212,255,0.25),_transparent_55%)]" />
+        <section className="relative mx-auto flex max-w-6xl flex-col gap-10 px-6 pb-24 pt-16 lg:flex-row lg:items-center">
+          <div className="flex-1 space-y-6">
+            <span className="inline-flex w-fit items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-1 text-xs uppercase tracking-[0.2em] text-white/80">
+              QLYK Studio
             </span>
-            <h1 className="text-3xl font-semibold sm:text-4xl">Fiches techniques instantanées pour boulangers et pâtissiers</h1>
-            <p className="text-sm sm:text-base text-white/80">
-              De la viennoiserie au flan en passant par la pâte à pizza, obtenez en quelques secondes une fiche claire,
-              professionnelle et adaptée à votre matériel. Prêt pour la production ?
+            <h1 className="text-4xl font-semibold leading-tight md:text-5xl">
+              L&apos;excellence visuelle augmentée par l&apos;intelligence artificielle.
+            </h1>
+            <p className="text-base text-white/80 md:text-lg">
+              QLYK Studio transforme vos photos brutes en contenus haut de gamme, fixes et animés, grâce à une IA
+              maîtrisée et une exigence de rendu sans compromis. Sublimez le réel, sans jamais le transformer.
             </p>
-            <ul className="grid gap-2 text-xs sm:grid-cols-3 sm:text-sm">
-              <li className="flex items-center gap-2">
-                <span className="flex h-6 w-6 items-center justify-center rounded-full bg-white/20 text-lg">⚙️</span>
-                <span>Adapter aux équipements sélectionnés</span>
-              </li>
-              <li className="flex items-center gap-2">
-                <span className="flex h-6 w-6 items-center justify-center rounded-full bg-white/20 text-lg">📏</span>
-                <span>Grammages recalculés instantanément</span>
-              </li>
-              <li className="flex items-center gap-2">
-                <span className="flex h-6 w-6 items-center justify-center rounded-full bg-white/20 text-lg">🧠</span>
-                <span>Tips de chef & check-list finale</span>
-              </li>
-            </ul>
+            <div className="flex flex-wrap gap-4">
+              <button className="button-primary">Demander une démonstration</button>
+              <button className="button-secondary">Voir nos réalisations</button>
+            </div>
+            <div className="flex flex-wrap gap-6 text-sm text-white/70">
+              <div className="flex items-center gap-2">
+                <span className="text-lg">⚡</span>
+                <span>Impact commercial immédiat</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-lg">🎯</span>
+                <span>Fidélité totale au réel</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-lg">⏱️</span>
+                <span>Livraison rapide</span>
+              </div>
+            </div>
+          </div>
+          <div className="flex-1">
+            <div className="glass-card space-y-6 p-8">
+              <h2 className="text-xl font-semibold">Notre mission</h2>
+              <p className="text-sm text-white/70">
+                Aider les professionnels à vendre mieux, plus vite et avec plus d&apos;impact, en révélant le plein
+                potentiel de leurs visuels, sans jamais trahir la réalité.
+              </p>
+              <div className="grid gap-4 text-sm text-white/70">
+                <div className="flex items-start gap-3">
+                  <span className="mt-1 text-lg">✔️</span>
+                  <span>Automobile, immobilier, produits, savoir-faire…</span>
+                </div>
+                <div className="flex items-start gap-3">
+                  <span className="mt-1 text-lg">✔️</span>
+                  <span>IA utilisée pour magnifier l&apos;existant, jamais pour inventer.</span>
+                </div>
+                <div className="flex items-start gap-3">
+                  <span className="mt-1 text-lg">✔️</span>
+                  <span>Visuels crédibles, rassurants et immédiatement exploitables.</span>
+                </div>
+              </div>
+            </div>
           </div>
         </section>
-
-        <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(260px,1fr)]">
-          <div className="space-y-6">
-            <RecipeForm onGenerate={handleGenerate} isGenerating={isGenerating} />
-            {currentRecipe ? (
-              <RecipeCard recipe={currentRecipe} onReset={() => setCurrentRecipe(null)} />
-            ) : (
-              <div className="card flex flex-col items-start gap-4 p-6 text-sm text-slate-600 sm:p-10">
-                <h2 className="text-lg font-semibold text-slate-900">Votre fiche apparaîtra ici</h2>
-                <p>
-                  Renseignez le formulaire ci-dessus pour générer automatiquement une fiche complète : ingrédients, matériel,
-                  étapes avec temps et astuces de chef.
-                </p>
-                <ul className="space-y-2 text-xs text-slate-500">
-                  <li>• Ajoutez plusieurs équipements pour obtenir des recommandations adaptées.</li>
-                  <li>• Les fiches restent enregistrées dans l'historique local pour consultation ultérieure.</li>
-                  <li>• Utilisez le bouton « Imprimer » pour obtenir une version papier ou PDF.</li>
-                </ul>
-              </div>
-            )}
-          </div>
-          <HistoryPanel entries={history} onSelect={handleSelectFromHistory} onClear={handleClearHistory} />
-        </div>
       </div>
+
+      <section className="mx-auto flex max-w-6xl flex-col gap-10 px-6 pb-20">
+        <div className="max-w-3xl space-y-4">
+          <p className="text-xs uppercase tracking-[0.3em] text-brand-light">Une approche unique</p>
+          <h2 className="text-3xl font-semibold">Sublimer le réel, jamais le transformer</h2>
+          <p className="text-white/70">
+            Chaque projet suit un protocole rigoureux, conçu pour préserver la vérité du visuel tout en maximisant son
+            impact émotionnel et commercial.
+          </p>
+        </div>
+        <div className="grid gap-6 md:grid-cols-2">
+          {[
+            {
+              title: "Analyse experte",
+              text: "Étude approfondie du visuel source et des objectifs de diffusion.",
+            },
+            {
+              title: "Correction technique",
+              text: "Redressement, colorimétrie précise et respect strict des matières.",
+            },
+            {
+              title: "Optimisation lumière & ambiance",
+              text: "Équilibre lumineux maîtrisé pour un rendu premium et authentique.",
+            },
+            {
+              title: "Rendu photo-réaliste",
+              text: "Visuels élégants, prêts à vendre, sans effets artificiels excessifs.",
+            },
+          ].map((item) => (
+            <div key={item.title} className="glass-card p-6">
+              <h3 className="text-lg font-semibold">{item.title}</h3>
+              <p className="mt-2 text-sm text-white/70">{item.text}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mx-auto flex max-w-6xl flex-col gap-10 px-6 pb-20">
+        <div className="grid gap-10 lg:grid-cols-[1.2fr_1fr]">
+          <div className="space-y-5">
+            <p className="text-xs uppercase tracking-[0.3em] text-brand-light">Photo & Vidéo</p>
+            <h2 className="text-3xl font-semibold">De la photo… à la vidéo courte à fort impact</h2>
+            <p className="text-white/70">
+              QLYK Studio transforme vos photos en vidéos courtes professionnelles (environ 8 secondes) pour captiver et
+              convertir sur tous vos supports.
+            </p>
+            <div className="space-y-3 text-sm text-white/70">
+              <div className="flex items-start gap-3">
+                <span className="mt-1 text-lg">🎬</span>
+                <span>Animations fluides, mouvements de caméra élégants et transitions cinématographiques sobres.</span>
+              </div>
+              <div className="flex items-start gap-3">
+                <span className="mt-1 text-lg">📣</span>
+                <span>Formats adaptés aux réseaux sociaux, publicités digitales et pages de vente premium.</span>
+              </div>
+              <div className="flex items-start gap-3">
+                <span className="mt-1 text-lg">🧩</span>
+                <span>Mise en scène cohérente avec l&apos;univers du bien ou du produit.</span>
+              </div>
+            </div>
+          </div>
+          <div className="glass-card flex flex-col gap-6 p-8">
+            <h3 className="text-xl font-semibold">Des contenus prêts à vendre</h3>
+            <ul className="space-y-4 text-sm text-white/70">
+              <li>✔️ Annonces premium et plateformes spécialisées.</li>
+              <li>✔️ Showrooms, vitrines et écrans événementiels.</li>
+              <li>✔️ Présentations commerciales haut de gamme.</li>
+              <li>✔️ Réseaux sociaux et campagnes ciblées.</li>
+            </ul>
+            <div className="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 text-sm text-white/70">
+              Toujours avec un principe fondamental : la réalité reste intacte.
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto flex max-w-6xl flex-col gap-10 px-6 pb-20">
+        <div className="max-w-3xl space-y-4">
+          <p className="text-xs uppercase tracking-[0.3em] text-brand-light">Expertises</p>
+          <h2 className="text-3xl font-semibold">Deux expertises mises en avant, une vision globale</h2>
+          <p className="text-white/70">
+            Des standards premium pour l&apos;automobile et l&apos;immobilier, appliqués ensuite à tous les secteurs où l&apos;image
+            doit séduire sans mentir.
+          </p>
+        </div>
+        <div className="grid gap-6 md:grid-cols-2">
+          <div className="glass-card p-6">
+            <h3 className="text-xl font-semibold">🚗 Automobile</h3>
+            <p className="mt-3 text-sm text-white/70">
+              Valorisation de véhicules à partir de photos simples, intégrées dans des décors premium sans aucune
+              modification du véhicule. Un rendu inspiré des standards des grandes marques.
+            </p>
+          </div>
+          <div className="glass-card p-6">
+            <h3 className="text-xl font-semibold">🏡 Immobilier</h3>
+            <p className="mt-3 text-sm text-white/70">
+              Photographie et vidéo immobilières réalistes : perspectives redressées, lumière optimisée, ambiance
+              maîtrisée, sans altération des volumes ou finitions.
+            </p>
+          </div>
+        </div>
+        <div className="grid gap-6 md:grid-cols-3">
+          {["Produits", "Lieux & architectures", "Créations & savoir-faire"].map((label) => (
+            <div key={label} className="glass-card p-6 text-sm text-white/70">
+              <span className="text-lg font-semibold text-white">{label}</span>
+              <p className="mt-2">La même exigence premium pour sublimer l&apos;existant et déclencher l&apos;envie.</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mx-auto flex max-w-6xl flex-col gap-10 px-6 pb-20">
+        <div className="glass-card p-8">
+          <div className="grid gap-8 lg:grid-cols-[1.2fr_1fr]">
+            <div className="space-y-4">
+              <h2 className="text-3xl font-semibold">Pourquoi choisir QLYK Studio ?</h2>
+              <p className="text-white/70">
+                Une expertise visuelle pensée pour générer confiance, émotion et conversion avec des contenus prêts à
+                vendre immédiatement.
+              </p>
+              <div className="grid gap-3 text-sm text-white/70 sm:grid-cols-2">
+                {[
+                  "Gain de temps et simplicité",
+                  "Photos et vidéos courtes à partir de vos visuels existants",
+                  "Rendu premium constant",
+                  "Fidélité totale à la réalité",
+                  "Contenus prêts à vendre immédiatement",
+                  "Image de marque renforcée",
+                ].map((item) => (
+                  <div key={item} className="flex items-start gap-3">
+                    <span className="mt-1 text-lg text-brand-light">✦</span>
+                    <span>{item}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="rounded-3xl border border-white/10 bg-slate-900/70 p-6 text-sm text-white/70">
+              <h3 className="text-lg font-semibold text-white">QLYK Studio</h3>
+              <p className="mt-2">L&apos;image et la vidéo professionnelles, sans compromis.</p>
+              <p className="mt-4 text-white/80">Vous fournissez les photos. Nous créons l&apos;impact visuel.</p>
+              <button className="button-primary mt-6 w-full">Programmer un échange</button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-slate-900/80">
+        <div className="mx-auto flex max-w-6xl flex-col items-center gap-6 px-6 py-16 text-center">
+          <p className="text-xs uppercase tracking-[0.3em] text-brand-light">Contact</p>
+          <h2 className="text-3xl font-semibold">QLYK Studio – Sublimer le réel, déclencher l&apos;envie.</h2>
+          <p className="max-w-2xl text-sm text-white/70">
+            Parlez-nous de vos visuels, de vos objectifs et des supports à privilégier. Nous construirons un rendu qui
+            valorise votre réalité et accélère vos ventes.
+          </p>
+          <div className="flex flex-wrap justify-center gap-4">
+            <button className="button-primary">Recevoir un devis</button>
+            <button className="button-secondary">Envoyer vos photos</button>
+          </div>
+          <p className="text-xs text-white/50">QLYK Studio © 2024</p>
+        </div>
+      </section>
     </main>
   );
 };

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,20 +1,18 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-  content: [
-    "./app/**/*.{js,ts,jsx,tsx}",
-    "./components/**/*.{js,ts,jsx,tsx}",
-  ],
+  content: ["./app/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {
       colors: {
         brand: {
-          DEFAULT: "#2F3C7E",
-          accent: "#FBEAEB",
+          DEFAULT: "#4C6FFF",
+          bright: "#8B5CFF",
+          light: "#00D4FF",
         },
       },
       boxShadow: {
-        soft: "0 20px 50px -20px rgba(47, 60, 126, 0.3)",
+        soft: "0 30px 80px -30px rgba(76, 111, 255, 0.35)",
       },
     },
   },


### PR DESCRIPTION
### Motivation
- Replace the existing recipe assistant homepage with a dedicated QLYK Studio landing page to match the visual identity and content brief.
- Reuse the same landing layout approach as other brand sites (hero, mission, features, CTAs, expertises) but adapt to QLYK color codes and tone.
- Introduce a premium, glassmorphism-driven visual style with clear CTAs to drive demo requests and contact actions.

### Description
- Replace `frontend/app/page.tsx` with a new QLYK Studio landing page including hero, mission, protocol, photo→video section, expertises, benefits and contact CTA. 
- Update `frontend/app/globals.css` to a dark theme, add `.button-primary`, `.button-secondary`, and `.glass-card` styles and global typography adjustments. 
- Update Tailwind config in `frontend/tailwind.config.ts` to the QLYK palette (`#4C6FFF`, `#8B5CFF`, `#00D4FF`) and increase the soft box-shadow to match the new design language. 
- Remove the previous recipe assistant UI references from the homepage and replace them with the brand-aligned sections and responsive layout (radial gradients, glass cards, CTA buttons). 

### Testing
- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000`, the app compiled and served the homepage (GET / returned 200) though the Next.js dev logs include a `fetch failed` / `ENETUNREACH` entry which did not prevent the server from becoming ready. 
- Ran a Playwright script to capture a screenshot of `http://127.0.0.1:3000`, which produced an artifact at `artifacts/qlyk-landing.png` successfully. 
- No unit or integration test suites were executed for this frontend-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a35c4a6908328999f928f9ea81332)